### PR TITLE
windows port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,15 @@
 
 # Bazel
 bazel-*
+packages/
 
 # Editors
 .clwb
 .idea
+
+#visual studio
+x64/
+*.user
+*.filters
+.vs/
+Debug/

--- a/mpc-utils.sln
+++ b/mpc-utils.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mpc_utils", "mpc_utils\mpc_utils.vcxproj", "{FDFED71A-E061-44FE-BA90-2197271D2941}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "temp", "temp\temp.vcxproj", "{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "msvc_mpc_util_tests", "msvc_mpc_util_tests\msvc_mpc_util_tests.vcxproj", "{06A2A486-12A0-4469-92F0-B57A3D6C5320}"
 EndProject
 Global
@@ -25,13 +23,6 @@ Global
 		{FDFED71A-E061-44FE-BA90-2197271D2941}.Release|x64.Build.0 = Release|x64
 		{FDFED71A-E061-44FE-BA90-2197271D2941}.Release|x86.ActiveCfg = Release|Win32
 		{FDFED71A-E061-44FE-BA90-2197271D2941}.Release|x86.Build.0 = Release|Win32
-		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Debug|x64.ActiveCfg = Debug|x64
-		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Debug|x86.ActiveCfg = Debug|Win32
-		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Debug|x86.Build.0 = Debug|Win32
-		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Release|x64.ActiveCfg = Release|x64
-		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Release|x64.Build.0 = Release|x64
-		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Release|x86.ActiveCfg = Release|Win32
-		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Release|x86.Build.0 = Release|Win32
 		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Debug|x64.ActiveCfg = Debug|x64
 		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Debug|x64.Build.0 = Debug|x64
 		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Debug|x86.ActiveCfg = Debug|Win32

--- a/mpc-utils.sln
+++ b/mpc-utils.sln
@@ -1,0 +1,50 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mpc_utils", "mpc_utils\mpc_utils.vcxproj", "{FDFED71A-E061-44FE-BA90-2197271D2941}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "temp", "temp\temp.vcxproj", "{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "msvc_mpc_util_tests", "msvc_mpc_util_tests\msvc_mpc_util_tests.vcxproj", "{06A2A486-12A0-4469-92F0-B57A3D6C5320}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FDFED71A-E061-44FE-BA90-2197271D2941}.Debug|x64.ActiveCfg = Debug|x64
+		{FDFED71A-E061-44FE-BA90-2197271D2941}.Debug|x64.Build.0 = Debug|x64
+		{FDFED71A-E061-44FE-BA90-2197271D2941}.Debug|x86.ActiveCfg = Debug|Win32
+		{FDFED71A-E061-44FE-BA90-2197271D2941}.Debug|x86.Build.0 = Debug|Win32
+		{FDFED71A-E061-44FE-BA90-2197271D2941}.Release|x64.ActiveCfg = Release|x64
+		{FDFED71A-E061-44FE-BA90-2197271D2941}.Release|x64.Build.0 = Release|x64
+		{FDFED71A-E061-44FE-BA90-2197271D2941}.Release|x86.ActiveCfg = Release|Win32
+		{FDFED71A-E061-44FE-BA90-2197271D2941}.Release|x86.Build.0 = Release|Win32
+		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Debug|x64.ActiveCfg = Debug|x64
+		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Debug|x86.ActiveCfg = Debug|Win32
+		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Debug|x86.Build.0 = Debug|Win32
+		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Release|x64.ActiveCfg = Release|x64
+		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Release|x64.Build.0 = Release|x64
+		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Release|x86.ActiveCfg = Release|Win32
+		{54F1BE9A-CBA8-4444-A480-F2FBADDC8F0E}.Release|x86.Build.0 = Release|Win32
+		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Debug|x64.ActiveCfg = Debug|x64
+		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Debug|x64.Build.0 = Debug|x64
+		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Debug|x86.ActiveCfg = Debug|Win32
+		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Debug|x86.Build.0 = Debug|Win32
+		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Release|x64.ActiveCfg = Release|x64
+		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Release|x64.Build.0 = Release|x64
+		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Release|x86.ActiveCfg = Release|Win32
+		{06A2A486-12A0-4469-92F0-B57A3D6C5320}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5323BD3B-55E4-47DA-93B3-383A840381DE}
+	EndGlobalSection
+EndGlobal

--- a/mpc_utils/BUILD
+++ b/mpc_utils/BUILD
@@ -101,6 +101,10 @@ cc_library(
     hdrs = [
         "comm_channel_emp_adapter.hpp",
     ],
+    defines = [
+        # Needed for Visual Studio compatibility.
+        "MPC_ENABLE_EMP_ADAPTER",
+    ],
     deps = [
         ":comm_channel",
         ":statusor",
@@ -130,6 +134,10 @@ cc_library(
     ],
     hdrs = [
         "comm_channel_oblivc_adapter.hpp",
+    ],
+    defines = [
+        # Needed for Visual Studio compatibility.
+        "MPC_ENABLE_OBLIVC_ADAPTER",
     ],
     deps = [
         ":comm_channel",

--- a/mpc_utils/boost_serialization/ntl.hpp
+++ b/mpc_utils/boost_serialization/ntl.hpp
@@ -16,7 +16,7 @@ inline void save(Archive& ar, const NTL::ZZ& z,
                  const unsigned int /* file_version */
 ) {
   std::vector<unsigned char> buf(NTL::NumBytes(z));
-  NTL::BytesFromZZ(buf.data(), z, buf.size());
+  NTL::BytesFromZZ(buf.data(), z, static_cast<long>(buf.size()));
   ar& buf;
 }
 template <class Archive>
@@ -24,7 +24,7 @@ inline void load(Archive& ar, NTL::ZZ& z, const unsigned int /* file_version */
 ) {
   std::vector<unsigned char> buf;
   ar& buf;
-  NTL::ZZFromBytes(z, buf.data(), buf.size());
+  NTL::ZZFromBytes(z, buf.data(), static_cast<long>(buf.size()));
 }
 
 // NTL::ZZ_p, NTL::zz_p

--- a/mpc_utils/comm_channel.cpp
+++ b/mpc_utils/comm_channel.cpp
@@ -7,8 +7,8 @@ namespace mpc_utils {
 
 // constructor called from party::connect_to
 comm_channel::comm_channel(std::unique_ptr<boost::asio::ip::tcp::iostream> &&s,
-                           party &p, int peer_id, bool measure_communication)
-    : p(p), id(p.get_id()), tcp_stream(std::move(s)), need_flush(false),
+                           party &p, int peer_id, bool measure_communication, std::unique_ptr<comm_channel> twin)
+    : p(p), id(p.get_id()), tcp_stream(std::move(s)), twin(std::move(twin)), need_flush(false),
       measure_communication(measure_communication), sent_byte_count(0),
       received_byte_count(0) {
   // Build output archive, optionally measuring communication.

--- a/mpc_utils/comm_channel.cpp
+++ b/mpc_utils/comm_channel.cpp
@@ -7,9 +7,15 @@ namespace mpc_utils {
 
 // constructor called from party::connect_to
 comm_channel::comm_channel(std::unique_ptr<boost::asio::ip::tcp::iostream> &&s,
-                           party &p, int peer_id, bool measure_communication, std::unique_ptr<comm_channel> twin)
-    : p(p), id(p.get_id()), tcp_stream(std::move(s)), twin(std::move(twin)), need_flush(false),
-      measure_communication(measure_communication), sent_byte_count(0),
+                           party &p, int peer_id, bool measure_communication,
+                           std::unique_ptr<comm_channel> twin)
+    : p(p),
+      id(p.get_id()),
+      tcp_stream(std::move(s)),
+      twin(std::move(twin)),
+      need_flush(false),
+      measure_communication(measure_communication),
+      sent_byte_count(0),
       received_byte_count(0) {
   // Build output archive, optionally measuring communication.
   if (!measure_communication) {
@@ -40,9 +46,9 @@ comm_channel::comm_channel(std::unique_ptr<boost::asio::ip::tcp::iostream> &&s,
   }
 
   if (peer_id == -1) {
-    recv(peer_id); // read id of remote
+    recv(peer_id);  // read id of remote
   } else {
-    send(this->id); // send own ID to remote
+    send(this->id);  // send own ID to remote
     flush();
   }
 
@@ -122,4 +128,4 @@ server_info comm_channel::get_peer_info() const {
   return p.get_servers()[peer_id];
 }
 
-} // namespace mpc_utils
+}  // namespace mpc_utils

--- a/mpc_utils/comm_channel.hpp
+++ b/mpc_utils/comm_channel.hpp
@@ -108,7 +108,7 @@ public:
   // even if measure_communication is set to true.
   int get_blocking_fd() {
     tcp_stream->rdbuf()->native_non_blocking(false);
-    return tcp_stream->rdbuf()->native_handle();
+    return static_cast<int>(tcp_stream->rdbuf()->native_handle());
   }
 
   // getters for both parties' IDs

--- a/mpc_utils/comm_channel.hpp
+++ b/mpc_utils/comm_channel.hpp
@@ -38,9 +38,10 @@ class CommChannelOblivCAdapter;
 
 // A bidirectional connection using the boost serialization library.
 class comm_channel {
-public:
+ public:
   comm_channel(std::unique_ptr<boost::asio::ip::tcp::iostream> &&s, party &p,
-               int peer_id, bool measure_communication = false, std::unique_ptr<comm_channel> twin = nullptr);
+               int peer_id, bool measure_communication = false,
+               std::unique_ptr<comm_channel> twin = nullptr);
 
   // No copy constructor: since copying a channel means establishing a new
   // connection, this should be done explicitly using clone()
@@ -62,29 +63,32 @@ public:
   }
 
   // send and receive objects via boost serialization
-  template <typename T> void send(T &&obj) {
+  template <typename T>
+  void send(T &&obj) {
     need_flush = true;
     COMM_CHANNEL_WRAP_EXCEPTION(*oarchive & obj,
                                 boost::archive::archive_exception);
   }
-  template <typename T> void recv(T &&obj) {
+  template <typename T>
+  void recv(T &&obj) {
     flush_if_needed();
     COMM_CHANNEL_WRAP_EXCEPTION(*iarchive & obj,
                                 boost::archive::archive_exception);
   }
   // send from `to_send` and receive into `to_recv` simultaneously
-  template <typename S, typename T> void send_recv(S &&to_send, T &&to_recv) {
+  template <typename S, typename T>
+  void send_recv(S &&to_send, T &&to_recv) {
     comm_channel &channel2 = *get_twin();
-    if (get_id() < get_peer_id()) { // lower ID sends on channel2
+    if (get_id() < get_peer_id()) {  // lower ID sends on channel2
       boost::thread t([&to_send, &channel2]() {
         channel2.send(to_send);
         channel2.flush();
       });
-      boost::thread_guard<> g(t); // join t when leaving scope
+      boost::thread_guard<> g(t);  // join t when leaving scope
       recv(to_recv);
-    } else { // higher ID receives on channel2
+    } else {  // higher ID receives on channel2
       boost::thread t([&to_recv, &channel2]() { channel2.recv(to_recv); });
-      boost::thread_guard<> g(t); // join t when leaving scope
+      boost::thread_guard<> g(t);  // join t when leaving scope
       send(to_send);
       flush();
     }
@@ -144,16 +148,16 @@ public:
   // Returns the server_infor for the remote endpoint.
   server_info get_peer_info() const;
 
-  // Returns twin comm_channel if one exists. If one does not exists 
-  // then it is created. 
+  // Returns twin comm_channel if one exists. If one does not exists
+  // then it is created.
   // Throws std::logic_error if called on a channel that doesn't have a twin.
-  comm_channel* get_twin() {
-      if (!twin) {
-        BOOST_THROW_EXCEPTION(std::logic_error("comm_channel does not have a twin"));
-      }
-      return twin.get();
+  comm_channel *get_twin() {
+    if (!twin) {
+      BOOST_THROW_EXCEPTION(
+          std::logic_error("comm_channel does not have a twin"));
+    }
+    return twin.get();
   }
-
 
   /**
    * Error info type for exceptions thrown from class methods
@@ -163,7 +167,7 @@ public:
   typedef party::error_num_servers error_num_servers;
   typedef boost::error_info<struct tag_STREAM_ERROR, std::string> stream_error;
 
-private:
+ private:
   friend class CommChannelEMPAdapter;
   friend class CommChannelOblivCAdapter;
 
@@ -178,8 +182,7 @@ private:
   // Used for sending and receiving simultaneously;
   // TODO: somehow allow for simultaneous reading and writing on the _same_
   //   socket
-  std::unique_ptr<comm_channel>
-      twin;
+  std::unique_ptr<comm_channel> twin;
   bool need_flush;
   // If set to true, all send and receive operations will count the number of
   // bytes sent or received, which can be retrieved using
@@ -197,9 +200,9 @@ private:
   }
 };
 
-} // namespace mpc_utils
+}  // namespace mpc_utils
 
 // TODO: remove this from the global namespace.
 using mpc_utils::comm_channel;
 
-#endif // MPC_UTILS_COMM_CHANNEL_HPP_
+#endif  // MPC_UTILS_COMM_CHANNEL_HPP_

--- a/mpc_utils/comm_channel.hpp
+++ b/mpc_utils/comm_channel.hpp
@@ -75,10 +75,7 @@ public:
   }
   // send from `to_send` and receive into `to_recv` simultaneously
   template <typename S, typename T> void send_recv(S &&to_send, T &&to_recv) {
-    if (!twin) {
-      twin = absl::WrapUnique(new comm_channel(clone()));
-    }
-    comm_channel &channel2 = *twin;
+    comm_channel &channel2 = *get_twin();
     if (get_id() < get_peer_id()) { // lower ID sends on channel2
       boost::thread t([&to_send, &channel2]() {
         channel2.send(to_send);
@@ -147,6 +144,16 @@ public:
 
   // Returns the server_infor for the remote endpoint.
   server_info get_peer_info() const;
+
+  // Returns twin comm_channel if one exists. If one does not exists 
+  // then it is created.
+  comm_channel* get_twin() { 
+      if (!twin) {
+          twin = absl::WrapUnique(new comm_channel(clone()));
+      }
+      return twin.get();
+  }
+
 
   /**
    * Error info type for exceptions thrown from class methods

--- a/mpc_utils/comm_channel_emp_adapter.cpp
+++ b/mpc_utils/comm_channel_emp_adapter.cpp
@@ -8,8 +8,8 @@
 
 namespace mpc_utils {
 
-StatusOr<std::unique_ptr<CommChannelEMPAdapter>>
-CommChannelEMPAdapter::Create(comm_channel *channel, bool direct) {
+StatusOr<std::unique_ptr<CommChannelEMPAdapter>> CommChannelEMPAdapter::Create(
+    comm_channel *channel, bool direct) {
   if (channel == nullptr) {
     return InvalidArgumentError("`channel` must not be NULL");
   }
@@ -42,5 +42,5 @@ CommChannelEMPAdapter::CommChannelEMPAdapter(comm_channel *channel,
                                              std::unique_ptr<emp::NetIO> net_io)
     : channel_(channel), net_io_(std::move(net_io)){};
 
-} // namespace mpc_utils
+}  // namespace mpc_utils
 #endif

--- a/mpc_utils/comm_channel_emp_adapter.cpp
+++ b/mpc_utils/comm_channel_emp_adapter.cpp
@@ -1,5 +1,7 @@
 #include "mpc_utils/comm_channel_emp_adapter.hpp"
 
+#ifdef MPC_ENABLE_EMP_ADAPTER
+
 #include "absl/memory/memory.h"
 #include "emp-tool/io/net_io_channel.h"
 #include "mpc_utils/canonical_errors.h"
@@ -41,3 +43,4 @@ CommChannelEMPAdapter::CommChannelEMPAdapter(comm_channel *channel,
     : channel_(channel), net_io_(std::move(net_io)){};
 
 } // namespace mpc_utils
+#endif

--- a/mpc_utils/comm_channel_emp_adapter.hpp
+++ b/mpc_utils/comm_channel_emp_adapter.hpp
@@ -4,6 +4,8 @@
 #ifndef MPC_UTILS_COMM_CHANNEL_EMP_ADAPTER_HPP_
 #define MPC_UTILS_COMM_CHANNEL_EMP_ADAPTER_HPP_
 
+#ifdef MPC_ENABLE_EMP_ADAPTER
+
 #include "emp-tool/io/io_channel.h"
 #include "emp-tool/io/net_io_channel.h"
 #include "mpc_utils/comm_channel.hpp"
@@ -69,4 +71,5 @@ class CommChannelEMPAdapter : public emp::IOChannel<CommChannelEMPAdapter> {
 
 }  // namespace mpc_utils
 
+#endif
 #endif  // MPC_UTILS_COMM_CHANNEL_EMP_ADAPTER_HPP_

--- a/mpc_utils/comm_channel_emp_adapter.hpp
+++ b/mpc_utils/comm_channel_emp_adapter.hpp
@@ -4,6 +4,7 @@
 #ifndef MPC_UTILS_COMM_CHANNEL_EMP_ADAPTER_HPP_
 #define MPC_UTILS_COMM_CHANNEL_EMP_ADAPTER_HPP_
 
+// Disable this adapter unless built by Bazel (which defines this macro).
 #ifdef MPC_ENABLE_EMP_ADAPTER
 
 #include "emp-tool/io/io_channel.h"

--- a/mpc_utils/comm_channel_emp_adapter_test.cpp
+++ b/mpc_utils/comm_channel_emp_adapter_test.cpp
@@ -1,4 +1,5 @@
 #include "mpc_utils/comm_channel_emp_adapter.hpp"
+#ifdef MPC_ENABLE_EMP_ADAPTER
 
 #include <iostream>
 #include <random>
@@ -70,3 +71,5 @@ TEST(CommChannelEMPAdapter, FailsIfMeasuredAndDirect) {
 }  // namespace
 
 }  // namespace mpc_utils
+
+#endif

--- a/mpc_utils/comm_channel_oblivc_adapter.cpp
+++ b/mpc_utils/comm_channel_oblivc_adapter.cpp
@@ -1,6 +1,6 @@
 #include "mpc_utils/comm_channel_oblivc_adapter.hpp"
 
-#ifdef MPC_ENABLE_OBLVC_ADAPTER
+#ifdef MPC_ENABLE_OBLIVC_ADAPTER
 #include <cerrno>
 #include <cstring>
 

--- a/mpc_utils/comm_channel_oblivc_adapter.cpp
+++ b/mpc_utils/comm_channel_oblivc_adapter.cpp
@@ -1,5 +1,6 @@
 #include "mpc_utils/comm_channel_oblivc_adapter.hpp"
 
+#ifdef MPC_ENABLE_OBLVC_ADAPTER
 #include <cerrno>
 #include <cstring>
 
@@ -63,3 +64,4 @@ StatusOr<ProtocolDesc> CommChannelOblivCAdapter::Connect(
 }
 
 }  // namespace mpc_utils
+#endif

--- a/mpc_utils/comm_channel_oblivc_adapter.hpp
+++ b/mpc_utils/comm_channel_oblivc_adapter.hpp
@@ -7,6 +7,10 @@
 
 #include "mpc_utils/comm_channel.hpp"
 #include "mpc_utils/statusor.h"
+
+#ifdef MPC_ENABLE_OBLVC_ADAPTER
+
+
 extern "C" {
 #include "obliv.h"
 };
@@ -24,5 +28,6 @@ class CommChannelOblivCAdapter {
 };
 
 }  // namespace mpc_utils
+#endif
 
 #endif  // MPC_UTILS_COMM_CHANNEL_OBLIVC_ADAPTER_HPP_

--- a/mpc_utils/comm_channel_oblivc_adapter.hpp
+++ b/mpc_utils/comm_channel_oblivc_adapter.hpp
@@ -8,7 +8,8 @@
 #include "mpc_utils/comm_channel.hpp"
 #include "mpc_utils/statusor.h"
 
-#ifdef MPC_ENABLE_OBLVC_ADAPTER
+// Disable this adapter unless built by Bazel (which defines this macro).
+#ifdef MPC_ENABLE_OBLIVC_ADAPTER
 
 
 extern "C" {

--- a/mpc_utils/comm_channel_oblivc_adapter.hpp
+++ b/mpc_utils/comm_channel_oblivc_adapter.hpp
@@ -11,7 +11,6 @@
 // Disable this adapter unless built by Bazel (which defines this macro).
 #ifdef MPC_ENABLE_OBLIVC_ADAPTER
 
-
 extern "C" {
 #include "obliv.h"
 };

--- a/mpc_utils/comm_channel_oblivc_adapter_test.cpp
+++ b/mpc_utils/comm_channel_oblivc_adapter_test.cpp
@@ -1,5 +1,5 @@
 #include "mpc_utils/comm_channel_oblivc_adapter.hpp"
-#ifdef MPC_ENABLE_OBLVC_ADAPTER
+#ifdef MPC_ENABLE_OBLIVC_ADAPTER
 
 #include "gtest/gtest.h"
 #include "mpc_utils/status_matchers.h"

--- a/mpc_utils/comm_channel_oblivc_adapter_test.cpp
+++ b/mpc_utils/comm_channel_oblivc_adapter_test.cpp
@@ -1,4 +1,5 @@
 #include "mpc_utils/comm_channel_oblivc_adapter.hpp"
+#ifdef MPC_ENABLE_OBLVC_ADAPTER
 
 #include "gtest/gtest.h"
 #include "mpc_utils/status_matchers.h"
@@ -124,3 +125,4 @@ TEST(CommChannelOblivc, SendSingleIntegerCircuitMeasured) {
 
 }  // namespace
 }  // namespace mpc_utils
+#endif

--- a/mpc_utils/config_test.cpp
+++ b/mpc_utils/config_test.cpp
@@ -6,31 +6,27 @@
 #include "boost/program_options.hpp"
 #include "gtest/gtest.h"
 
-
 #ifdef _MSC_VER
 #pragma warning(disable : 4996)
 #include "windows.h"
 
-std::wstring GetWC(const char* c)
-{
-    const size_t cSize = strlen(c);
-    std::wstring wc; wc.resize(cSize);
-    mbstowcs((wchar_t*)wc.data(), c, cSize);
-    return wc;
+std::wstring GetWC(const char* c) {
+  const size_t cSize = strlen(c);
+  std::wstring wc;
+  wc.resize(cSize);
+  mbstowcs((wchar_t*)wc.data(), c, cSize);
+  return wc;
 }
 
-void setenv(const char* name, const wchar_t* val, int overwrite)
-{
-    auto nl = strlen(name);
-    std::wstring nn;
+void setenv(const char* name, const wchar_t* val, int overwrite) {
+  auto nl = strlen(name);
+  std::wstring nn;
 
-    SetEnvironmentVariable(GetWC(name).c_str(), val);
+  SetEnvironmentVariable(GetWC(name).c_str(), val);
 }
 
-
-void unsetenv(const char* name)
-{
-    SetEnvironmentVariable(GetWC(name).c_str(), NULL);
+void unsetenv(const char* name) {
+  SetEnvironmentVariable(GetWC(name).c_str(), NULL);
 }
 
 #endif

--- a/mpc_utils/config_test.cpp
+++ b/mpc_utils/config_test.cpp
@@ -6,6 +6,35 @@
 #include "boost/program_options.hpp"
 #include "gtest/gtest.h"
 
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4996)
+#include "windows.h"
+
+std::wstring GetWC(const char* c)
+{
+    const size_t cSize = strlen(c);
+    std::wstring wc; wc.resize(cSize);
+    mbstowcs((wchar_t*)wc.data(), c, cSize);
+    return wc;
+}
+
+void setenv(const char* name, const wchar_t* val, int overwrite)
+{
+    auto nl = strlen(name);
+    std::wstring nn;
+
+    SetEnvironmentVariable(GetWC(name).c_str(), val);
+}
+
+
+void unsetenv(const char* name)
+{
+    SetEnvironmentVariable(GetWC(name).c_str(), NULL);
+}
+
+#endif
+
 namespace mpc_utils {
 namespace {
 

--- a/mpc_utils/deps.bzl
+++ b/mpc_utils/deps.bzl
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 load("@mpc_utils//third_party:repo.bzl", "third_party_http_archive")
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 load("@com_github_schoppmp_rules_oblivc//oblivc:deps.bzl", "oblivc_deps")
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 all_content = """
 filegroup(

--- a/mpc_utils/mpc_utils.vcxproj
+++ b/mpc_utils/mpc_utils.vcxproj
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{FDFED71A-E061-44FE-BA90-2197271D2941}</ProjectGuid>
+    <RootNamespace>mpcutils</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>mpc_utils</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)/../../abseil-cpp;$(ProjectDir)/../../benchmark\include\;$(ProjectDir)/../../googletest\googletest\include;$(ProjectDir)/../../googletest\googlemock\include;$(ProjectDir)../;C:\libs\boost\;C:\libs\ntl\include\;C:\libs\eigen;C:\libs\OpenSSL\include\</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)/../../abseil-cpp;$(ProjectDir)/../../benchmark\include\;$(ProjectDir)/../../googletest\googletest\include;$(ProjectDir)/../../googletest\googlemock\include;$(ProjectDir)../;C:\libs\boost\;C:\libs\ntl\include\;C:\libs\eigen;C:\libs\OpenSSL\include\</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="benchmarker.cpp" />
+    <ClCompile Include="boost_serialization\abseil_test.cpp" />
+    <ClCompile Include="boost_serialization\eigen_test.cpp" />
+    <ClCompile Include="boost_serialization\ntl_test.cpp" />
+    <ClCompile Include="canonical_errors.cc" />
+    <ClCompile Include="comm_channel.cpp" />
+    <ClCompile Include="comm_channel_emp_adapter.cpp" />
+    <ClCompile Include="comm_channel_oblivc_adapter.cpp" />
+    <ClCompile Include="config.cpp" />
+    <ClCompile Include="config_test.cpp" />
+    <ClCompile Include="mpc_config.cpp" />
+    <ClCompile Include="openssl_uniform_bit_generator_benchmark.cpp" />
+    <ClCompile Include="party.cpp" />
+    <ClCompile Include="server_info.cpp" />
+    <ClCompile Include="status.cc" />
+    <ClCompile Include="testing\comm_channel_test_helper.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="benchmarker.hpp" />
+    <ClInclude Include="boost_serialization\abseil.hpp" />
+    <ClInclude Include="boost_serialization\eigen.hpp" />
+    <ClInclude Include="boost_serialization\ntl.hpp" />
+    <ClInclude Include="canonical_errors.h" />
+    <ClInclude Include="comm_channel.hpp" />
+    <ClInclude Include="comm_channel_emp_adapter.hpp" />
+    <ClInclude Include="comm_channel_oblivc_adapter.hpp" />
+    <ClInclude Include="config.hpp" />
+    <ClInclude Include="counter.hpp" />
+    <ClInclude Include="mpc_config.hpp" />
+    <ClInclude Include="openssl_uniform_bit_generator.hpp" />
+    <ClInclude Include="party.hpp" />
+    <ClInclude Include="server_info.hpp" />
+    <ClInclude Include="status.h" />
+    <ClInclude Include="statusor.h" />
+    <ClInclude Include="status_internal.h" />
+    <ClInclude Include="status_macros.h" />
+    <ClInclude Include="status_matchers.h" />
+    <ClInclude Include="testing\comm_channel_test_helper.hpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/mpc_utils/party.cpp
+++ b/mpc_utils/party.cpp
@@ -5,12 +5,12 @@
 namespace mpc_utils {
 
 comm_channel party::connect_to(int peer_id, bool measure_communication,
-                               bool tcp_nodelay, int sleep_time,
-                               int num_tries, bool create_twin) {
+                               bool tcp_nodelay, int sleep_time, int num_tries,
+                               bool create_twin) {
   using tcp = boost::asio::ip::tcp;
   try {
     if (peer_id == ANY_PEER) {
-      peer_id = servers.size(); // accept any connection
+      peer_id = servers.size();  // accept any connection
     }
     if (static_cast<unsigned>(peer_id) >= pending.size() || peer_id == id) {
       BOOST_THROW_EXCEPTION(
@@ -18,7 +18,7 @@ comm_channel party::connect_to(int peer_id, bool measure_communication,
           << error_num_servers(servers.size()));
     }
     if (!pending[peer_id]
-             .empty()) { // if we already have a connection, return it
+             .empty()) {  // if we already have a connection, return it
       auto chan = std::move(pending[peer_id].back());
       pending[peer_id].pop_back();
       return chan;
@@ -28,35 +28,38 @@ comm_channel party::connect_to(int peer_id, bool measure_communication,
       try {
         for (;;) {
           std::unique_ptr<tcp::iostream> stream(new tcp::iostream());
-          { // Keep acceptor around for only one accept call to allow for recursive calls to connect_to. Needed for twin channel.
+          {  // Keep acceptor around for only one accept call to allow for
+             // recursive calls to connect_to. Needed for twin channel.
             tcp::endpoint endpoint(tcp::v6(), servers[id].port);
             tcp::acceptor acceptor(io_service, endpoint);
             acceptor.set_option(boost::asio::socket_base::reuse_address(true));
-              acceptor.accept(*(stream->rdbuf()));
+            acceptor.accept(*(stream->rdbuf()));
           }
           if (tcp_nodelay) {
-            stream->rdbuf()->set_option(tcp::no_delay(true)); // disable nagle
+            stream->rdbuf()->set_option(tcp::no_delay(true));  // disable nagle
           }
           // Create twin channel if required.
           std::unique_ptr<comm_channel> twin = nullptr;
-          if(create_twin) {
-            twin = absl::WrapUnique(new comm_channel(connect_to(peer_id, measure_communication, tcp_nodelay, sleep_time, num_tries, false)));
-          } 
-          comm_channel chan(std::move(stream), *this, -1,
-                            measure_communication, std::move(twin));
+          if (create_twin) {
+            twin = absl::WrapUnique(new comm_channel(
+                connect_to(peer_id, measure_communication, tcp_nodelay,
+                           sleep_time, num_tries, false)));
+          }
+          comm_channel chan(std::move(stream), *this, -1, measure_communication,
+                            std::move(twin));
           int current_id = chan.get_peer_id();
           if (current_id > static_cast<int>(servers.size())) {
-            current_id = servers.size(); // not a server -> put into last queue
+            current_id = servers.size();  // not a server -> put into last queue
             // or return via ANY_PEER'
           }
-          if (current_id == peer_id) { // found the one we're looking for
+          if (current_id == peer_id) {  // found the one we're looking for
             return chan;
           }
           if (current_id >= 0 &&
               static_cast<unsigned>(current_id) < pending.size() &&
               current_id != id) {
             pending[current_id].push_back(std::move(
-                chan)); // save channel for later; TODO: allow multiple
+                chan));  // save channel for later; TODO: allow multiple
             // simultaneous connections from the same peer
           } else {
             // invalid id -> connection gets closed when chan leaves scope
@@ -68,7 +71,7 @@ comm_channel party::connect_to(int peer_id, bool measure_communication,
       } catch (boost::archive::archive_exception &ex) {
         BOOST_THROW_EXCEPTION(ex);
       }
-    } else { // connect
+    } else {  // connect
       for (int i = 0; i < num_tries || num_tries == -1; i++) {
         try {
           try {
@@ -79,12 +82,15 @@ comm_channel party::connect_to(int peer_id, bool measure_communication,
             // try connecting
             boost::asio::connect(*(stream->rdbuf()), resolver.resolve(query));
             if (tcp_nodelay) {
-              stream->rdbuf()->set_option(tcp::no_delay(true)); // disable nagle
+              stream->rdbuf()->set_option(
+                  tcp::no_delay(true));  // disable nagle
             }
             // Create twin channel if required.
             std::unique_ptr<comm_channel> twin = nullptr;
-            if(create_twin) {
-              twin = absl::WrapUnique(new comm_channel(connect_to(peer_id, measure_communication, tcp_nodelay, sleep_time, num_tries, false)));
+            if (create_twin) {
+              twin = absl::WrapUnique(new comm_channel(
+                  connect_to(peer_id, measure_communication, tcp_nodelay,
+                             sleep_time, num_tries, false)));
             }
             return comm_channel(std::move(stream), *this, peer_id,
                                 measure_communication, std::move(twin));
@@ -95,7 +101,7 @@ comm_channel party::connect_to(int peer_id, bool measure_communication,
             BOOST_THROW_EXCEPTION(ex);
           }
         } catch (boost::exception &ex) {
-          if (i == num_tries - 1) { // last try -> re-throw
+          if (i == num_tries - 1) {  // last try -> re-throw
             throw;
           }
           boost::this_thread::sleep_for(
@@ -105,7 +111,7 @@ comm_channel party::connect_to(int peer_id, bool measure_communication,
       BOOST_THROW_EXCEPTION(
           std::runtime_error("Could not connect to server, giving up"));
     }
-  } catch (boost::exception &ex) { // add information to exceptions
+  } catch (boost::exception &ex) {  // add information to exceptions
     ex << error_my_id(id) << error_peer_id(peer_id);
     throw;
   }
@@ -113,4 +119,4 @@ comm_channel party::connect_to(int peer_id, bool measure_communication,
 
 absl::Span<const server_info> party::get_servers() const { return servers; }
 
-} // namespace mpc_utils
+}  // namespace mpc_utils

--- a/mpc_utils/party.hpp
+++ b/mpc_utils/party.hpp
@@ -40,7 +40,7 @@ public:
   int get_id() { return id; }
 
   // Return the number of servers.
-  int get_num_servers() { return servers.size(); }
+  int get_num_servers() { return static_cast<int>(servers.size()); }
 
   // Returns a view of the servers.
   absl::Span<const server_info> get_servers() const;

--- a/mpc_utils/party.hpp
+++ b/mpc_utils/party.hpp
@@ -19,13 +19,15 @@ class comm_channel;
 
 // represents a participant in an MPC protocol
 class party {
-public:
+ public:
   static const int DEFAULT_SLEEP_TIME = 500;
   static const int DEFAULT_NUM_TRIES = -1;
   party(mpc_config &conf)
-      : servers(conf.servers), id(conf.party_id),
+      : servers(conf.servers),
+        id(conf.party_id),
         io_thread(boost::bind(&boost::asio::io_service::run, &io_service)),
-        resolver(io_service), io_guard(io_thread),
+        resolver(io_service),
+        io_guard(io_thread),
         pending(servers.size() + 1){};
 
   // Establishes a connection to a party with ID party_id and returns a pointer
@@ -52,19 +54,19 @@ public:
 
   static const int ANY_PEER = -1;
 
-private:
-  std::vector<server_info> servers;   // list of all servers sorted by party id
-  int id;                             // this party's ID
-  boost::asio::io_service io_service; // IO context for this party
-  boost::thread io_thread;            // runs io.run()
+ private:
+  std::vector<server_info> servers;    // list of all servers sorted by party id
+  int id;                              // this party's ID
+  boost::asio::io_service io_service;  // IO context for this party
+  boost::thread io_thread;             // runs io.run()
   boost::asio::ip::tcp::resolver resolver;
-  boost::thread_guard<> io_guard; // joins io_thread whend destroyed
+  boost::thread_guard<> io_guard;  // joins io_thread whend destroyed
   std::vector<std::vector<comm_channel>> pending;
 };
 
-} // namespace mpc_utils
+}  // namespace mpc_utils
 
 // TODO: remove this from the global namespace.
 using mpc_utils::party;
 
-#endif // MPC_UTILS_PARTY_HPP_
+#endif  // MPC_UTILS_PARTY_HPP_

--- a/mpc_utils/party.hpp
+++ b/mpc_utils/party.hpp
@@ -29,12 +29,12 @@ public:
         pending(servers.size() + 1){};
 
   // Establishes a connection to a party with ID party_id and returns a pointer
-  // to an object representing that connection. Suitable for passing to SCAPI
-  // calls
+  // to an object representing that connection.
   comm_channel connect_to(int peer_id, bool measure_communication = false,
                           bool tcp_nodelay = true,
                           int sleep_time = DEFAULT_SLEEP_TIME,
-                          int num_tries = DEFAULT_NUM_TRIES);
+                          int num_tries = DEFAULT_NUM_TRIES,
+                          bool create_twin = true);
 
   // Return this party's ID.
   int get_id() { return id; }
@@ -59,7 +59,6 @@ private:
   boost::thread io_thread;            // runs io.run()
   boost::asio::ip::tcp::resolver resolver;
   boost::thread_guard<> io_guard; // joins io_thread whend destroyed
-  std::mutex connection_mutex; // allow only one concurrent call to connect_to
   std::vector<std::vector<comm_channel>> pending;
 };
 

--- a/mpc_utils/preload.bzl
+++ b/mpc_utils/preload.bzl
@@ -10,28 +10,28 @@ def mpc_utils_deps_preload():
     if "com_google_absl" not in native.existing_rules():
         http_archive(
             name = "com_google_absl",
-            urls = ["https://github.com/abseil/abseil-cpp/archive/ccdd1d57b6386ebc26fb0c7d99b604672437c124.zip"],
-            strip_prefix = "abseil-cpp-ccdd1d57b6386ebc26fb0c7d99b604672437c124",
-            sha256 = "a463a791e1b5eaad461956495401357efb792fcdbf47b5737ec420bb54c804b6",
+            urls = ["https://github.com/abseil/abseil-cpp/archive/3b4a16abad2c2ddc494371cc39a2946e36d35d11.zip"],
+            strip_prefix = "abseil-cpp-3b4a16abad2c2ddc494371cc39a2946e36d35d11",
+            sha256 = "64c43686598cf554d9e91fa9a6dafd87a84d7ce9f667dccdd3971b5b249960dc",
         )
     if "com_github_nelhage_rules_boost" not in native.existing_rules():
         http_archive(
             name = "com_github_nelhage_rules_boost",
-            sha256 = "ea88159d5b91a852de0cd8ccdc78c9ca42c54538241aa7ff727de3544da7f051",
-            strip_prefix = "rules_boost-fe9a0795e909f10f2bfb6bfa4a51e66641e36557",
-            url = "https://github.com/nelhage/rules_boost/archive/fe9a0795e909f10f2bfb6bfa4a51e66641e36557.zip",
+            strip_prefix = "rules_boost-c13a880269cc044c4b5e90046625339836771d77",
+            url = "https://github.com/nelhage/rules_boost/archive/c13a880269cc044c4b5e90046625339836771d77.zip",
+            sha256 = "19a51f2f67e6bd2d1655a0641568bd88211db641a77c27fcdab7d9ad6de7dc00",
         )
     if "com_github_schoppmp_rules_oblivc" not in native.existing_rules():
         http_archive(
             name = "com_github_schoppmp_rules_oblivc",
-            sha256 = "10f53f0fab3e374fdef83dc4279d902a357993a87c91d6de3c30e64db59f87ee",
-	    url = "https://github.com/schoppmp/rules_oblivc/archive/d33ab3a707b9d6e9a79a683e660e572ab8e92f16.zip",
-            strip_prefix = "rules_oblivc-d33ab3a707b9d6e9a79a683e660e572ab8e92f16",
+	        url = "https://github.com/schoppmp/rules_oblivc/archive/84d26968342777bf9c6b9734d560fa1464ac865f.zip",
+            strip_prefix = "rules_oblivc-84d26968342777bf9c6b9734d560fa1464ac865f",
+            sha256 = "d82326ab62c4a383ce4284446739181236b6744fba874d5fe53bfbdde369da29",
         )
     if "rules_foreign_cc" not in native.existing_rules():
         http_archive(
             name = "rules_foreign_cc",
-            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/74b146dc87d37baa1919da1e8f7b8aafbd32acd9.zip",
-            strip_prefix = "rules_foreign_cc-74b146dc87d37baa1919da1e8f7b8aafbd32acd9",
-            sha256 = "2de65ab702ebd0094da3885aae2a6a370df5edb4c9d0186096de79dffb356dbc",
+            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/1f48d7756c8cb1361ce9cb9c7205036047d162e0.zip",
+            strip_prefix = "rules_foreign_cc-1f48d7756c8cb1361ce9cb9c7205036047d162e0",
+            sha256 = "382a2343cfd4cd1d94d7d89d9d2b7e15e48fc614e9371b4aeaf13e1161794b40",
         )

--- a/mpc_utils/server_info.cpp
+++ b/mpc_utils/server_info.cpp
@@ -6,11 +6,9 @@ namespace mpc_utils {
 
 int server_info::compare(const server_info &other) const {
   int ret = host.compare(other.host);
-  if (!ret) { // hostnames equal
-    if (port < other.port)
-      return -1;
-    if (port > other.port)
-      return 1;
+  if (!ret) {  // hostnames equal
+    if (port < other.port) return -1;
+    if (port > other.port) return 1;
     return 0;
   }
   return ret;
@@ -20,4 +18,4 @@ std::ostream &operator<<(std::ostream &stream, const server_info &server) {
   return stream << "Server host: " << server.host << ", port: " << server.port;
 }
 
-} // namespace mpc_utils
+}  // namespace mpc_utils

--- a/mpc_utils/server_info.hpp
+++ b/mpc_utils/server_info.hpp
@@ -31,7 +31,7 @@ struct server_info {
   };
 };
 
-} // namespace mpc_utils
+}  // namespace mpc_utils
 
 using mpc_utils::server_info;
 

--- a/msvc_mpc_util_tests/msvc_mpc_util_tests.vcxproj
+++ b/msvc_mpc_util_tests/msvc_mpc_util_tests.vcxproj
@@ -1,0 +1,127 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{06a2a486-12a0-4469-92f0-b57a3d6c5320}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\mpc_utils\benchmarker_test.cpp" />
+    <ClCompile Include="..\mpc_utils\boost_serialization\abseil_test.cpp" />
+    <ClCompile Include="..\mpc_utils\boost_serialization\eigen_test.cpp" />
+    <ClCompile Include="..\mpc_utils\boost_serialization\ntl_test.cpp" />
+    <ClCompile Include="..\mpc_utils\comm_channel_emp_adapter_test.cpp" />
+    <ClCompile Include="..\mpc_utils\comm_channel_oblivc_adapter_test.cpp" />
+    <ClCompile Include="..\mpc_utils\comm_channel_test.cpp" />
+    <ClCompile Include="..\mpc_utils\openssl_uniform_bit_generator_test.cpp" />
+  </ItemGroup>
+  <ItemDefinitionGroup />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(ProjectDir)/../../abseil-cpp;$(ProjectDir)/../../benchmark\include\;$(ProjectDir)/../../googletest\googletest\include__;$(ProjectDir)/../../googletest\googlemock\include;$(ProjectDir)../;C:\libs\boost\;C:\libs\ntl\include\;C:\libs\eigen;C:\libs\OpenSSL\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(ProjectDir)../x64/$(Configuration);C:\libs\boost\stage\lib;C:\libs\ntl\x64\$(Configuration)\;C:\libs\eigen;C:\libs\OpenSSL\lib;$(ProjectDir)../../abseil-cpp\absl\numeric\$(Configuration)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>mpc_utils.lib;ntl.lib;libssl.lib;libcrypto.lib;absl_int128.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(ProjectDir)/../../abseil-cpp;$(ProjectDir)/../../benchmark\include\;$(ProjectDir)/../../googletest\googletest\include__;$(ProjectDir)/../../googletest\googlemock\include;$(ProjectDir)../;C:\libs\boost\;C:\libs\ntl\include\;C:\libs\eigen;C:\libs\OpenSSL\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalLibraryDirectories>$(ProjectDir)../x64/$(Configuration);C:\libs\boost\stage\lib;C:\libs\ntl\x64\$(Configuration)\;C:\libs\eigen;C:\libs\OpenSSL\lib;$(ProjectDir)../../abseil-cpp\absl\numeric\$(Configuration)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>mpc_utils.lib;ntl.lib;libssl.lib;libcrypto.lib;absl_int128.lib;$(MSBuildThisFileDirectory)..\..\lib\native\v140\windesktop\msvcstl\static\rt-dyn\x64\Release\gtest_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+  </Target>
+</Project>

--- a/msvc_mpc_util_tests/packages.config
+++ b/msvc_mpc_util_tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />
+</packages>

--- a/third_party/eigen/BUILD
+++ b/third_party/eigen/BUILD
@@ -1,10 +1,10 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
 
 licenses(["restricted"])
 
-cmake_external(
+cmake(
     name = "eigen",
-    headers_only = True,
+    out_headers_only = True,
     lib_source = "@org_tuxfamily_eigen//:all",
     out_include_dir = "include/eigen3",
     visibility = ["//visibility:public"],

--- a/third_party/emp_ot.BUILD
+++ b/third_party/emp_ot.BUILD
@@ -1,5 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
 
 licenses(["notice"])  # MIT
 
@@ -15,13 +14,13 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
-cmake_external(
+cmake(
     name = "emp_ot",
     cache_entries = {
         "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/emp_tool;$EXT_BUILD_DEPS/gmp",
         "GMP_INCLUDE_DIR": "$EXT_BUILD_DEPS/gmp/include",
     },
-    headers_only = True,
+    out_headers_only = True,
     lib_source = ":all",
     make_commands = [
         "make install/fast",

--- a/third_party/emp_tool.BUILD
+++ b/third_party/emp_tool.BUILD
@@ -1,5 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
 
 licenses(["notice"])  # MIT
 
@@ -8,7 +7,7 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-cmake_external(
+cmake(
     name = "emp_tool",
     cache_entries = {
         "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS;$EXT_BUILD_DEPS/relic;$EXT_BUILD_DEPS/gmp",
@@ -25,7 +24,7 @@ cmake_external(
         "make emp-tool -j $(nproc)",
         "make install/fast",
     ],
-    shared_libraries = [
+    out_shared_libs = [
         "libemp-tool.so",
     ],
     visibility = ["//visibility:public"],

--- a/third_party/gmp/BUILD
+++ b/third_party/gmp/BUILD
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
 licenses(["restricted"])
 
@@ -9,7 +9,7 @@ configure_make(
       "--enable-cxx",
       "CXX=g++",  #Needed presumably because of a bug in GMP's configure script.
     ],
-    static_libraries = [
+    out_static_libs = [
         "libgmp.a",
         "libgmpxx.a",
     ],

--- a/third_party/gperftools/BUILD
+++ b/third_party/gperftools/BUILD
@@ -1,10 +1,10 @@
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
 licenses(["notice"])  # BSD 3-clause
 
 configure_make(
     name = "gperftools",
-    binaries = [
+    out_binaries = [
         "pprof",
     ],
     configure_options = [
@@ -13,7 +13,7 @@ configure_make(
         "--disable-libunwind",
     ],
     lib_source = "@com_github_gperftools_gperftools//:all",
-    shared_libraries = [
+    out_shared_libs = [
         "libtcmalloc_and_profiler.so.4",
     ],
     visibility = ["//visibility:public"],

--- a/third_party/ntl/BUILD
+++ b/third_party/ntl/BUILD
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
 licenses(["restricted"])
 
@@ -14,7 +14,7 @@ configure_make(
         "make",
         "make install",
     ],
-    static_libraries = ["libntl.a"],
+    out_static_libs = ["libntl.a"],
     visibility = ["//visibility:public"],
     deps = [
         "//third_party/gmp",

--- a/third_party/relic.BUILD
+++ b/third_party/relic.BUILD
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//foreign_cc:cmake.bzl", "cmake")
 
 licenses(["notice"])  # Apache
 
@@ -7,7 +7,7 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-cmake_external(
+cmake(
     name = "relic",
     cache_entries = {
         # Needed for EMP.
@@ -32,7 +32,7 @@ cmake_external(
         "CMAKE_PREFIX_PATH": "$EXT_BUILD_DEPS/gmp/",
     },
     lib_source = ":all",
-    static_libraries = [
+    out_static_libs = [
         "librelic_s.a",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Hey, ran tests in windows and ubuntu and everything seems to work. Though when I run using `bazel test ...` is complains about a memory leak. IDK what's up with that. 

On thing i'll call your attention too are `MPC_ENABLE_EMP_ADAPTER`, `MPC_ENABLE_OBLVC_ADAPTER`.

These guard the includes to EMP and Obliv-C. I dont have them defined by default. 

Seem like it would be a good idea to have bazel be able to optionally include these dependancies and if they are here define these macros. Is this something you can do?